### PR TITLE
Remove Charset#forName from standard charset check

### DIFF
--- a/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
+++ b/gradle-baseline-java-config/resources/checkstyle/checkstyle.xml
@@ -290,7 +290,7 @@
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">
-            <property name="format" value="\bCharset.forName\(|\bCharsets\."/>
+            <property name="format" value="\bCharsets\."/>
             <property name="message" value="Use JDK StandardCharsets instead of alternatives."/>
         </module>
         <module name="RegexpSinglelineJava">


### PR DESCRIPTION
Example use case we have:

```
.charset(Charset.forName(line.substring(charsetIndex + 8).trim()))
```
